### PR TITLE
feature:OP-19353:added new Dockerfileubi8 for RHEL ubi8.7-minimal-changes

### DIFF
--- a/Dockerfile.ubi8-minimal
+++ b/Dockerfile.ubi8-minimal
@@ -1,0 +1,24 @@
+FROM alpine:3 AS build
+RUN apk add --update \
+    openjdk11 \
+    && rm -rf /var/cache/apk
+LABEL maintainer="sig-platform@spinnaker.io"
+ENV GRADLE_USER_HOME /workspace/.gradle
+ENV GRADLE_OPTS -Xmx4g
+WORKDIR /build
+COPY . /build
+RUN ./gradlew --no-daemon echo-web:installDist -x test
+
+ARG TARGETARCH
+
+FROM quay.io/opsmxpublic/image-base-java-ubi8-minimal:latest AS package
+LABEL maintainer="info@opsmx.io"
+
+RUN  microdnf install --setopt=tsflags=nodocs openssh-clients \
+ && groupadd -g 10111 spinnaker \
+ && useradd -g spinnaker -u 10111 spinnaker  \
+ && mkdir -p /opt/echo/plugins && chown -R spinnaker:spinnaker /opt/echo/plugins
+
+COPY --from=build /build/echo-web/build/install/echo /opt/echo
+USER spinnaker
+CMD ["/opt/echo/bin/echo"]

--- a/Dockerfileubi8
+++ b/Dockerfileubi8
@@ -1,0 +1,16 @@
+# Not using the alpine image because it lacks a package gRPC needed to establish pub/sub listeners.
+#FROM openjdk:11
+#LABEL maintainer="sig-platform@spinnaker.io"
+#RUN adduser --system --uid 10111 --group spinnaker
+
+FROM quay.io/opsmxpublic/ubi8-jdk-11:v1
+LABEL maintainer="info@opsmx.io"
+
+RUN  microdnf install --setopt=tsflags=nodocs openssh-clients  && \
+  groupadd -g 10111 spinnaker && \
+  useradd -g spinnaker -u 10111 spinnaker && \
+  mkdir -p /opt/echo/plugins && chown -R spinnaker:spinnaker /opt/echo/plugins
+
+COPY echo-web/build/install/echo /opt/echo
+USER spinnaker
+CMD ["/opt/echo/bin/echo"]


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-19353
Changes done :

Copied Dockerfile.slim to Dockerfileubi8
Changed the base image from alpine to redhat
--- javabase file is committed at :
https://github.com/OpsMx/image-base-java/blob/main/Dockerfile
--- image is built and uploaded at:
http://quay.io/opsmxpublic/ubi8-jdk-11:v1

Added command to microdnf install required packages
Added group with group-id and added user with user-id
Changed ownership to plugins to the above spinnaker:spinnaker
Combined all RUN commands in single RUN command to avoid multiple layers