### PR TITLE
refactor(cron-scheduler): added version 2.3.2 > 2.5.0-rc1 to fix weekly cve trivy report

### DIFF
--- a/echo-scheduler/echo-scheduler.gradle
+++ b/echo-scheduler/echo-scheduler.gradle
@@ -41,7 +41,7 @@ dependencies {
   }
 
   implementation "org.springframework:spring-context-support"
-  implementation ("org.quartz-scheduler:quartz") {
+  implementation ("org.quartz-scheduler:quartz:2.5.0-rc1") {
     exclude group: 'com.zaxxer', module: 'HikariCP-java7'
   }
 }

--- a/echo-web/echo-web.gradle
+++ b/echo-web/echo-web.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'net.redhogs.cronparser:cron-parser-core:2.8'
     implementation "org.springframework.data:spring-data-rest-webmvc"
     implementation "org.springframework:spring-context-support"
-    implementation("org.quartz-scheduler:quartz") {
+    implementation("org.quartz-scheduler:quartz:2.5.0-rc1") {
       exclude group: 'com.zaxxer', module: 'HikariCP-java7'
     }
 


### PR DESCRIPTION
add latest current version for org.quartz-scheduler:quartz 2.3.2 > 2.4.0-rc1 for CVE-30Aug trivy report