### PR TITLE
Fixed Webhook Issue - OP-21224

### DIFF
--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BaseTriggerEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/BaseTriggerEventHandler.java
@@ -74,9 +74,9 @@ public abstract class BaseTriggerEventHandler<T extends TriggerEvent>
     }
 
     Map<String, List<Trigger>> triggers = pipelineCache.getEnabledTriggersSync();
-
     List<Pipeline> pipelines = new ArrayList<>();
     if (successfulTriggerEvent) {
+      log.debug("successfulTriggerEvent - BaseTriggerEventHandler");
       pipelines =
           supportedTriggerTypes().stream()
               .flatMap(
@@ -92,9 +92,8 @@ public abstract class BaseTriggerEventHandler<T extends TriggerEvent>
               .map(Optional::get)
               .distinct()
               .collect(Collectors.toList());
-    }
-
-    if (unstableTriggerEvent) {
+    } else if (unstableTriggerEvent) {
+      log.debug("unstableTriggerEvent - BaseTriggerEventHandler");
       pipelines =
           (Optional.ofNullable(triggers.get(JENKINS_TRIGGER_TYPE))
                   .orElse(Collections.emptyList())
@@ -108,6 +107,7 @@ public abstract class BaseTriggerEventHandler<T extends TriggerEvent>
               .distinct()
               .collect(Collectors.toList());
     }
+    log.debug("pipelinesData" + pipelines);
     log.debug("End of the get matching Pipelines - BaseTriggerEventHandler");
     return pipelines;
   }

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/ManualEventHandler.java
@@ -112,15 +112,8 @@ public class ManualEventHandler implements TriggerEventHandler<ManualEvent> {
       return Collections.emptyList();
     }
     List<Pipeline> pipelines = new ArrayList<>();
-    if (successfulTriggerEvent) {
-      pipelines =
-          pipelineCache.getPipelinesSync().stream()
-              .map(p -> withMatchingTrigger(event, p))
-              .filter(Optional::isPresent)
-              .map(Optional::get)
-              .collect(Collectors.toList());
-    }
-    if (unstableTriggerEvent && isJenkinsBuildTriggerAndUnstableBuild(event)) {
+    if (successfulTriggerEvent
+        || (unstableTriggerEvent && isJenkinsBuildTriggerAndUnstableBuild(event))) {
       pipelines =
           pipelineCache.getPipelinesSync().stream()
               .map(p -> withMatchingTrigger(event, p))

--- a/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/TriggerEventHandler.java
+++ b/echo-pipelinetriggers/src/main/java/com/netflix/spinnaker/echo/pipelinetriggers/eventhandlers/TriggerEventHandler.java
@@ -75,6 +75,6 @@ public interface TriggerEventHandler<T extends TriggerEvent> {
   }
 
   default boolean isUnstableTriggerEvent(T event) {
-    return true;
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

**Issue :** https://devopsmx.atlassian.net/browse/OP-21224 (Variable reassignment issue)
**Solution :** Fixed by directly returning it, instead of reassign

### How changes are verified
Create & deploy docker img with given changes : aman1603/trigger:fixed2 & found that pipeline is triggering successfully on github commit

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA