### PR TITLE
OP-21856 Fixed CVE-2023-39017 - Remove explicit version of Quartz

### DIFF
--- a/echo-scheduler/echo-scheduler.gradle
+++ b/echo-scheduler/echo-scheduler.gradle
@@ -41,7 +41,7 @@ dependencies {
   }
 
   implementation "org.springframework:spring-context-support"
-  implementation ("org.quartz-scheduler:quartz:2.5.0-rc1") {
+  implementation ("org.quartz-scheduler:quartz") {
     exclude group: 'com.zaxxer', module: 'HikariCP-java7'
   }
 }

--- a/echo-web/echo-web.gradle
+++ b/echo-web/echo-web.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'net.redhogs.cronparser:cron-parser-core:2.8'
     implementation "org.springframework.data:spring-data-rest-webmvc"
     implementation "org.springframework:spring-context-support"
-    implementation("org.quartz-scheduler:quartz:2.5.0-rc1") {
+    implementation("org.quartz-scheduler:quartz") {
       exclude group: 'com.zaxxer', module: 'HikariCP-java7'
     }
 


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21856
**Summary** : Removed explicit quartz version, as required version v[2.5.0-rc1](https://mvnrepository.com/artifact/org.quartz-scheduler/quartz/2.5.0-rc1) is coming from kork-bom
**Testing** :
1. compile successful, no new TCs failed bcoz of this.
2. Build kork-changes & publish it to local maven, build echo, create docker image : aman1603/echo:5march1, deployed to cvetarget ns, cron pipeline reran successful : [ref](https://deck.cve.opsmx.net/#/applications/aman/executions?pipeline=cron)
3. Created trivy-scan locally, this CVE not found

**Pre-merge** : Merge https://github.com/OpsMx/kork-oes/pull/126
**Post-merge** : QA regression testing