### PR TITLE
Fixed EmailNotificationServiceSpec & ApplicationSpec

### DIFF
--- a/echo-notifications/echo-notifications.gradle
+++ b/echo-notifications/echo-notifications.gradle
@@ -45,10 +45,9 @@ dependencies {
   implementation "io.cloudevents:cloudevents-http-basic:2.5.0"
   implementation "io.cloudevents:cloudevents-json-jackson:2.5.0"
   implementation ("dev.cdevents:cdevents-sdk-java:0.1.2")
-  testImplementation("com.icegreen:greenmail:1.5.14") {
-    exclude group: "com.sun.mail", module: "javax.mail"
-  }
   implementation "org.apache.groovy:groovy:4.0.9"
+
+  testImplementation "com.icegreen:greenmail:2.0.1"
   testImplementation "org.apache.httpcomponents:httpclient"
   testImplementation "org.spockframework:spock-spring"
   testImplementation "org.springframework:spring-test"

--- a/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/email/EmailNotificationServiceSpec.groovy
+++ b/echo-notifications/src/test/groovy/com/netflix/spinnaker/echo/email/EmailNotificationServiceSpec.groovy
@@ -22,6 +22,7 @@ import com.icegreen.greenmail.util.GreenMailUtil
 import com.icegreen.greenmail.util.ServerSetupTest
 import com.netflix.spinnaker.echo.api.Notification
 import com.netflix.spinnaker.echo.notification.NotificationTemplateEngine
+import jakarta.mail.Message
 import jakarta.mail.internet.MimeMessage
 import org.springframework.mail.javamail.JavaMailSenderImpl
 import spock.lang.Shared
@@ -29,9 +30,7 @@ import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
-
-
-class EmailNotificationServiceSpec { /*extends Specification
+class EmailNotificationServiceSpec extends Specification {
   def notificationTemplateEngine = Mock(NotificationTemplateEngine)
 
   @Shared
@@ -97,5 +96,5 @@ class EmailNotificationServiceSpec { /*extends Specification
     ['receiver@localhost another@localhost']  | ['some-addr@localhost some-other-addr@localhost']  || ['receiver@localhost', 'another@localhost'] || ['some-addr@localhost', 'some-other-addr@localhost']
     ['receiver@localhost,another@localhost']  | ['some-addr@localhost,some-other-addr@localhost']  || ['receiver@localhost', 'another@localhost'] || ['some-addr@localhost', 'some-other-addr@localhost']
     ['receiver@localhost; another@localhost'] | ['some-addr@localhost, some-other-addr@localhost'] || ['receiver@localhost', 'another@localhost'] || ['some-addr@localhost', 'some-other-addr@localhost']
-  }*/
+  }
 }

--- a/echo-web/src/test/java/com/netflix/spinnaker/echo/ApplicationSpec.java
+++ b/echo-web/src/test/java/com/netflix/spinnaker/echo/ApplicationSpec.java
@@ -20,12 +20,12 @@ import com.netflix.spinnaker.echo.pipelinetriggers.orca.OrcaService;
 import com.netflix.spinnaker.echo.services.Front50Service;
 import com.netflix.spinnaker.fiat.shared.FiatService;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
-/*@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {Application.class})*/
+@SpringBootTest(classes = {Application.class})
 @ContextConfiguration(classes = {Application.class})
 @TestPropertySource(properties = {"spring.config.location=classpath:echo-test.yml"})
 public class ApplicationSpec {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,5 @@ spinnakerGradleVersion=1-0-SNAPSHOT
 #
 #fiatComposite=true
 #korkComposite=true
+
+org.gradle.jvmargs=-Xmx2g -Xms2g


### PR DESCRIPTION
**Summary** :
Latest vulnerability free version : https://mvnrepository.com/artifact/com.icegreen/greenmail/2.0.1
Didnt contain javax.mail as previous version, so no need to remove, as it contains com.sun.mail:jakarta.mail

**Testing** : 7/7 EmailNotificationServiceSpec UTs passed, 1/1 ApplicationSpec UT passes